### PR TITLE
Rename IClean

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace></RootNamespace>
+    <RootNamespace />
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.2.1" />
+    <PackageReference Include="Nuke.Common" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[5.11.1]" />
-    <PackageDownload Include="NuGet.CommandLine" Version="[6.3.1]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
+    <PackageDownload Include="NuGet.CommandLine" Version="[6.5.0]" />
   </ItemGroup>
 
 </Project>

--- a/src/BeatSaberModdingTools.Nuke/Components/ICleanRefs.cs
+++ b/src/BeatSaberModdingTools.Nuke/Components/ICleanRefs.cs
@@ -3,8 +3,8 @@ using static Nuke.Common.IO.FileSystemTasks;
 
 namespace BeatSaberModdingTools.Nuke.Components;
 
-public interface IClean : IProvideRefsDirectory
+public interface ICleanRefs : IProvideRefsDirectory
 {
-	Target Clean => _ => _
+	Target CleanRefs => _ => _
 		.Executes(() => EnsureCleanDirectory(RefsDirectory));
 }

--- a/src/BeatSaberModdingTools.Nuke/Components/IDeserializeManifest.cs
+++ b/src/BeatSaberModdingTools.Nuke/Components/IDeserializeManifest.cs
@@ -15,8 +15,8 @@ public interface IDeserializeManifest : IProvideSourceDirectory
 	AbsolutePath ManifestPath => TryGetValue(() => ManifestPath) ?? SourceDirectory / "manifest.json";
 
 	Target DeserializeManifest => _ => _
-		.TryAfter<IClean>()
-		.Requires(() => !string.IsNullOrWhiteSpace(ManifestPath)).Executes((Func<Task>)(async () =>
+		.Requires(() => !string.IsNullOrWhiteSpace(ManifestPath))
+		.Executes((Func<Task>)(async () =>
 		{
 			Assert.FileExists(ManifestPath);
 

--- a/src/BeatSaberModdingTools.Nuke/Components/IDownloadBeatModsDependencies.cs
+++ b/src/BeatSaberModdingTools.Nuke/Components/IDownloadBeatModsDependencies.cs
@@ -20,7 +20,7 @@ public interface IDownloadBeatModsDependencies : IProvideRefsDirectory
 	private static Dictionary<string, VersionRange> Dependencies => IDeserializeManifest.Manifest!.Dependencies;
 
 	Target DownloadDependencies => _ => _
-		.TryAfter<IClean>()
+		.TryAfter<ICleanRefs>()
 		.DependsOn<IDeserializeManifest>(x => x.DeserializeManifest)
 		.OnlyWhenDynamic(() => Dependencies.Count > 0).Executes((Func<Task>)(async () =>
 		{

--- a/src/BeatSaberModdingTools.Nuke/Components/IDownloadGameRefs.cs
+++ b/src/BeatSaberModdingTools.Nuke/Components/IDownloadGameRefs.cs
@@ -16,6 +16,7 @@ public interface IDownloadGameRefs : IProvideRefsDirectory
 	string? SiraServerCode => TryGetValue(() => SiraServerCode);
 
 	Target DownloadGameRefs => _ => _
+		.TryAfter<ICleanRefs>()
 		.DependsOn<IDeserializeManifest>(x => x.DeserializeManifest)
 		.Requires(() => !string.IsNullOrWhiteSpace(SiraServerCode))
 		.OnlyWhenDynamic(() => !string.IsNullOrWhiteSpace(GameVersion))


### PR DESCRIPTION
Renames the IClean component interface and related build target to ICleanRefs which conveys the usage of the target better.
Also upgrade dependencies.